### PR TITLE
Fixed: mismatch title with content

### DIFF
--- a/HowToInstallJava.MD
+++ b/HowToInstallJava.MD
@@ -1,7 +1,7 @@
 # Overview
 A step-by-step guide on how to install Java on AWS CentOS 7.
 
-# How to Generate An SSH Key
+# How to Install Java
 1. Connect to EC2 Instance
 2. Execute Install Command
 ![Execute Install Command](screenshots/java/1-execute-install-command.png)


### PR DESCRIPTION
It should be 'How to Install Java'.